### PR TITLE
Show all (not just top-level) search results

### DIFF
--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -24,6 +24,7 @@
 
       <form class="sidebar-search" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>">
         <input type="hidden" name="repos" value="<?php echo $resource->id ?>">
+        <input type="hidden" name="topLod" value="0"/>
         <div class="input-prepend input-append">
           <input type="text" name="query" value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search') ?>">
           <button class="btn" type="submit">


### PR DESCRIPTION
Currently, when a user searches a repository/distinctive collection from
the left-hand search box only the top-level (collection) results are
displayed. The user should see results from any level of the record.